### PR TITLE
refactor: axios から fetch に移行する

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@book000/node-utils": "1.24.123",
     "@types/config": "4.4.0",
     "@types/node": "24.12.2",
-    "axios": "1.15.0",
     "config": "4.4.1",
     "eslint": "10.2.0",
     "eslint-config-standard": "17.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
-      axios:
-        specifier: 1.15.0
-        version: 1.15.0
       config:
         specifier: 4.4.1
         version: 4.4.1
@@ -449,9 +446,6 @@ packages:
 
   axios@1.14.0:
     resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
-
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2031,14 +2025,6 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   axios@1.14.0:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.5
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5

--- a/src/lib/epgstation.ts
+++ b/src/lib/epgstation.ts
@@ -1,5 +1,3 @@
-import axios from 'axios'
-
 interface EPGVideoFile {
   id: number
   name: string
@@ -47,23 +45,26 @@ export interface EPGChannel {
 
 export class EPGStation {
   public async getRecordeds(): Promise<EPGRecorded[]> {
-    const response = await axios.get<{
-      records: EPGRecorded[]
-    }>('http://localhost:8888/api/recorded?isHalfWidth=false&limit=300')
-    return response.data.records
+    const res = await fetch(
+      'http://localhost:8888/api/recorded?isHalfWidth=false&limit=300'
+    )
+    if (!res.ok)
+      throw new Error(`EPGStation getRecordeds failed: ${res.status}`)
+    return ((await res.json()) as { records: EPGRecorded[] }).records
   }
 
   public async getRecordings(): Promise<EPGRecorded[]> {
-    const response = await axios.get<{
-      records: EPGRecorded[]
-    }>('http://localhost:8888/api/recording?&isHalfWidth=true&limit=300')
-    return response.data.records
+    const res = await fetch(
+      'http://localhost:8888/api/recording?&isHalfWidth=true&limit=300'
+    )
+    if (!res.ok)
+      throw new Error(`EPGStation getRecordings failed: ${res.status}`)
+    return ((await res.json()) as { records: EPGRecorded[] }).records
   }
 
   public async getChannels(): Promise<EPGChannel[]> {
-    const response = await axios.get<EPGChannel[]>(
-      'http://localhost:8888/api/channels'
-    )
-    return response.data
+    const res = await fetch('http://localhost:8888/api/channels')
+    if (!res.ok) throw new Error(`EPGStation getChannels failed: ${res.status}`)
+    return (await res.json()) as EPGChannel[]
   }
 }

--- a/src/lib/syoboi.ts
+++ b/src/lib/syoboi.ts
@@ -76,7 +76,7 @@ export class Syoboi {
         ([k, v]) => [k, String(v)] as [string, string]
       )
     )
-    const res = await fetch(`https://cal.syoboi.jp/json.php?${params}`)
+    const res = await fetch(`https://cal.syoboi.jp/json.php?${params.toString()}`)
     if (!res.ok) throw new Error(`Syoboi requestJSON failed: ${res.status}`)
     const data = (await res.json()) as {
       Titles: Record<string, SyoboiJsonResult>
@@ -92,7 +92,7 @@ export class Syoboi {
         ([k, v]) => [k, String(v)] as [string, string]
       )
     )
-    const res = await fetch(`https://cal.syoboi.jp/rss2.php?${params}`)
+    const res = await fetch(`https://cal.syoboi.jp/rss2.php?${params.toString()}`)
     if (!res.ok) throw new Error(`Syoboi requestRSS failed: ${res.status}`)
     const data = (await res.json()) as { items: SyoboiRssResult[] }
     return data.items

--- a/src/lib/syoboi.ts
+++ b/src/lib/syoboi.ts
@@ -76,7 +76,9 @@ export class Syoboi {
         ([k, v]) => [k, String(v)] as [string, string]
       )
     )
-    const res = await fetch(`https://cal.syoboi.jp/json.php?${params.toString()}`)
+    const res = await fetch(
+      `https://cal.syoboi.jp/json.php?${params.toString()}`
+    )
     if (!res.ok) throw new Error(`Syoboi requestJSON failed: ${res.status}`)
     const data = (await res.json()) as {
       Titles: Record<string, SyoboiJsonResult>
@@ -92,7 +94,9 @@ export class Syoboi {
         ([k, v]) => [k, String(v)] as [string, string]
       )
     )
-    const res = await fetch(`https://cal.syoboi.jp/rss2.php?${params.toString()}`)
+    const res = await fetch(
+      `https://cal.syoboi.jp/rss2.php?${params.toString()}`
+    )
     if (!res.ok) throw new Error(`Syoboi requestRSS failed: ${res.status}`)
     const data = (await res.json()) as { items: SyoboiRssResult[] }
     return data.items

--- a/src/lib/syoboi.ts
+++ b/src/lib/syoboi.ts
@@ -1,5 +1,3 @@
-import axios from 'axios'
-
 type requestJsonCommands =
   | 'TitleMedium'
   | 'TitleLarge'
@@ -73,23 +71,26 @@ export class Syoboi {
   public async requestJSON(
     options: SyoboiJsonOptions
   ): Promise<SyoboiJsonResult> {
-    const response = await axios.get<{
+    const params = new URLSearchParams(
+      Object.entries(options).map(([k, v]) => [k, String(v)] as [string, string])
+    )
+    const res = await fetch(`https://cal.syoboi.jp/json.php?${params}`)
+    if (!res.ok) throw new Error(`Syoboi requestJSON failed: ${res.status}`)
+    const data = (await res.json()) as {
       Titles: Record<string, SyoboiJsonResult>
-    }>('https://cal.syoboi.jp/json.php', {
-      params: options,
-    })
-    return response.data.Titles[options.TID]
+    }
+    return data.Titles[options.TID]
   }
 
   public async requestRSS(
     options: SyoboiRssOptions
   ): Promise<SyoboiRssResult[]> {
-    const response = await axios.get<{
-      items: SyoboiRssResult[]
-    }>('https://cal.syoboi.jp/rss2.php', {
-      params: options,
-    })
-
-    return response.data.items
+    const params = new URLSearchParams(
+      Object.entries(options).map(([k, v]) => [k, String(v)] as [string, string])
+    )
+    const res = await fetch(`https://cal.syoboi.jp/rss2.php?${params}`)
+    if (!res.ok) throw new Error(`Syoboi requestRSS failed: ${res.status}`)
+    const data = (await res.json()) as { items: SyoboiRssResult[] }
+    return data.items
   }
 }

--- a/src/lib/syoboi.ts
+++ b/src/lib/syoboi.ts
@@ -72,7 +72,9 @@ export class Syoboi {
     options: SyoboiJsonOptions
   ): Promise<SyoboiJsonResult> {
     const params = new URLSearchParams(
-      Object.entries(options).map(([k, v]) => [k, String(v)] as [string, string])
+      Object.entries(options).map(
+        ([k, v]) => [k, String(v)] as [string, string]
+      )
     )
     const res = await fetch(`https://cal.syoboi.jp/json.php?${params}`)
     if (!res.ok) throw new Error(`Syoboi requestJSON failed: ${res.status}`)
@@ -86,7 +88,9 @@ export class Syoboi {
     options: SyoboiRssOptions
   ): Promise<SyoboiRssResult[]> {
     const params = new URLSearchParams(
-      Object.entries(options).map(([k, v]) => [k, String(v)] as [string, string])
+      Object.entries(options).map(
+        ([k, v]) => [k, String(v)] as [string, string]
+      )
     )
     const res = await fetch(`https://cal.syoboi.jp/rss2.php?${params}`)
     if (!res.ok) throw new Error(`Syoboi requestRSS failed: ${res.status}`)

--- a/src/lib/utlis.ts
+++ b/src/lib/utlis.ts
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import { execSync } from 'node:child_process'
 import config from 'config'
 import fs from 'node:fs'
@@ -263,20 +262,22 @@ export async function sendDiscordMessage(
   const logger = Logger.configure('Utils.sendDiscordMessage')
   const discordChannelId = config.get<string>('discordChannelId')
   const discordToken = config.get<string>('discordToken')
-  const response = await axios.post(
+  const res = await fetch(
     `https://discord.com/api/channels/${discordChannelId}/messages`,
     {
-      content,
-      embeds: [embed],
-    },
-    {
+      method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bot ${discordToken}`,
       },
+      body: JSON.stringify({
+        content,
+        embeds: [embed],
+      }),
     }
   )
-  logger.info(`📧 sendDiscordMessage: ${response.status}`)
+  if (!res.ok) throw new Error(`sendDiscordMessage failed: ${res.status}`)
+  logger.info(`📧 sendDiscordMessage: ${res.status}`)
 }
 
 export function pad(num: number, size = 2): string {
@@ -303,10 +304,12 @@ export async function checkLatest(): Promise<boolean> {
   const branch = config.has('repo.branch')
     ? config.get<string>('repo.branch')
     : 'master'
-  const response = await axios.get<{
-    sha: string
-  }>(`https://api.github.com/repos/${repo}/commits/${branch}`)
-  const latest = response.data.sha
+  const res = await fetch(
+    `https://api.github.com/repos/${repo}/commits/${branch}`
+  )
+  if (!res.ok) throw new Error(`checkLatest failed: ${res.status}`)
+  const data = (await res.json()) as { sha: string }
+  const latest = data.sha
   const current = execSync('git rev-parse HEAD').toString().trim()
   if (latest !== current) {
     logger.error(`❗ checkLatest: ${current} is not latest: ${latest}`)


### PR DESCRIPTION
fix book000/book000#102

axiosへの依存を削除し、ネイティブ fetch API に移行しました。

## 変更内容
- `axios` 依存を削除
- `fetch` API を使用するように変更
- 非2xxレスポンスに対するエラーハンドリングを追加