### PR TITLE
fix: TypeScript v6 対応のため tsconfig に ignoreDeprecations と rootDir を追加

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,11 +23,9 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
     "newLine": "LF",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "moduleResolution": "Node",
     "lib": ["ESNext", "esnext.AsyncIterable"],
+    "rootDir": "./src",
     "outDir": "./dist",
     "removeComments": true,
     "esModuleInterop": true,
@@ -23,6 +24,7 @@
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "newLine": "LF",
     "paths": {
       "@/*": ["src/*"]


### PR DESCRIPTION
## 概要

Renovate PR #2363 (`chore(deps): update dependency typescript to v6`) で TypeScript v6 に更新した際に発生するコンパイルエラーを修正します。

## 変更内容

### `tsconfig.json`

- `"rootDir": "./src"` を追加
  - TS5011: `'rootDir' must be explicitly set` エラーを解消
  - ソースディレクトリが `src/` のみであることを明示

- `"baseUrl": "."` を除去
  - TS5101: `'baseUrl' is deprecated` エラーを解消
  - TypeScript 4.1 以降、`baseUrl` なしで `paths` を使用可能

- `paths` の値を相対パス形式に変更 (`"src/*"` → `"./src/*"`)
  - `baseUrl` 除去に伴う調整
  - `baseUrl` なしでの `paths` 設定では相対パスが必要

## 解消されるエラー

| エラーコード | 内容 |
|---|---|
| TS5101 | `'baseUrl' is deprecated` |
| TS5011 | `'rootDir' must be explicitly set` |

## 未解決のエラー

| エラーコード | 内容 | 対処方針 |
|---|---|---|
| TS5107 | `'moduleResolution=node10' is deprecated` | Renovate の TypeScript v6 更新 PR にて別途対処予定 |

`ignoreDeprecations: "6.0"` は TypeScript 5.x では TS5103 エラーとなるため、現時点では使用しません。
TS5107 は TypeScript v6 に更新後、`moduleResolution: "nodenext"` 等への移行、または `ignoreDeprecations: "6.0"` の追加で解消できます。

## 備考

- Renovate が管理する PR #2363 には変更を加えていません
- `@/*` パスエイリアスはソースコード内で未使用ですが、`paths` エントリは互換性のため維持しています