### PR TITLE
fix(tsconfig): TypeScript v6.0 に向けた moduleResolution と types の修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "module": "commonjs",
-    "moduleResolution": "Node",
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "types": ["node"],
     "lib": ["ESNext", "esnext.AsyncIterable"],
     "rootDir": "./src",
     "outDir": "./dist",


### PR DESCRIPTION
## 概要

TypeScript v6.0 で非推奨・廃止となる設定を `tsconfig.json` から修正します。

Fixes #2519

## 変更内容

### `tsconfig.json`

| 変更前 | 変更後 | 理由 |
|--------|--------|------|
| `"module": "commonjs"` | `"module": "Node16"` | `moduleResolution: "node16"` との整合性 |
| `"moduleResolution": "Node"` | `"moduleResolution": "node16"` | TypeScript 7.0 で `Node`（旧 node10）が削除予定のため |
| なし | `"types": ["node"]` | TypeScript 6.0 で `@types/node` の自動ロードが廃止されたため |

## 修正の詳細

### TS5107 対応: `moduleResolution: "Node"` の廃止

TypeScript 6.0 では `moduleResolution: "Node"`（旧 node10 相当）が非推奨となり、TypeScript 7.0 で削除予定です。

Node.js + CommonJS プロジェクトでは `node16` が推奨されます（`node:` プレフィックスのインポートにも対応）。なお、`moduleResolution: "node16"` を指定する場合は `module: "Node16"` も合わせて指定する必要があります。

### TS2591 対応: `@types/node` の自動ロード廃止

TypeScript 6.0 では `@types/node` が自動的にロードされなくなりました（`types` のデフォルトが `[]` に変更）。`types: ["node"]` を明示的に追加することで解決します。