### PR TITLE
fix(lint): unicorn/prefer-array-some ルール違反を修正

### DIFF
--- a/src/lib/utlis.ts
+++ b/src/lib/utlis.ts
@@ -124,8 +124,10 @@ export async function processFileName(
     logger.info(`❗ ${file.name} is encoding or recording`)
     return null
   }
-  const channel = channels.find((channel) => channel.id === recorded.channelId)
-  if (!channel) {
+  const hasChannel = channels.some(
+    (channel) => channel.id === recorded.channelId
+  )
+  if (!hasChannel) {
     logger.error(`❗ ${file.name} is get channel failed`)
     return null
   }


### PR DESCRIPTION
## 概要

`@book000/eslint-config` の更新（PR #2513）に伴い、`eslint-plugin-unicorn` v65 系で新たに有効化された `unicorn/prefer-array-some` ルールに違反していた箇所を修正します。

## 変更内容

### `src/lib/utlis.ts` (127 行目)

`channels.find()` の戻り値を存在チェック（`!channel`）のみに使用していたパターンを、`channels.some()` に書き換えました。

**変更前:**
```typescript
const channel = channels.find((channel) => channel.id === recorded.channelId)
if (!channel) {
```

**変更後:**
```typescript
const hasChannel = channels.some(
  (channel) => channel.id === recorded.channelId
)
if (!hasChannel) {
```

## 確認事項

- [x] `pnpm lint` でエラーなし（ESLint・Prettier・tsc すべて通過）
- [x] ビルド（`tsc --noEmit`）エラーなし

Fixes #2522