### PR TITLE
fix(lint): resolve eslint-plugin-unicorn violations from @book000/eslint-config bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/tomacheese/cmcutter/issues"
   },
   "devDependencies": {
-    "@book000/eslint-config": "1.15.4",
+    "@book000/eslint-config": "1.15.44",
     "@book000/node-utils": "1.24.274",
     "@types/config": "4.4.0",
     "@types/node": "24.13.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@book000/eslint-config':
-        specifier: 1.15.4
-        version: 1.15.4(eslint@10.6.0)(typescript@6.0.3)
+        specifier: 1.15.44
+        version: 1.15.44(eslint@10.6.0)(typescript@6.0.3)
       '@book000/node-utils':
         specifier: 1.24.274
         version: 1.24.274
@@ -28,10 +28,10 @@ importers:
         version: 10.6.0
       eslint-config-standard:
         specifier: 17.1.0
-        version: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0))(eslint-plugin-n@18.2.1(eslint@10.6.0)(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3))(eslint-plugin-promise@7.3.0(eslint@10.6.0))(eslint@10.6.0)
+        version: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0))(eslint-plugin-n@18.2.1(eslint@10.6.0)(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3))(eslint-plugin-promise@7.3.0(eslint@10.6.0))(eslint@10.6.0)
       eslint-plugin-import:
         specifier: 2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)
+        version: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)
       eslint-plugin-n:
         specifier: 18.2.1
         version: 18.2.1(eslint@10.6.0)(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3)
@@ -56,14 +56,10 @@ importers:
 
 packages:
 
-  '@babel/helper-validator-identifier@7.29.7':
-    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
-    engines: {node: '>=6.9.0'}
-
-  '@book000/eslint-config@1.15.4':
-    resolution: {integrity: sha512-ZoYNeauKfLCW1EaJNd2ISRcfqIHEYWJyHrKV4vag8iOlou+eXdvZw60EWKnqvznNBpkaeLg4MmgM5m7M5dWBlQ==}
+  '@book000/eslint-config@1.15.44':
+    resolution: {integrity: sha512-N1lvgGdTMNphDTVWbtOslyGSjC75R0O5mawxdnWtrWaClrMNNLC7X2SgI5CM01HO0B3fMpVeGfDDM9220E0+bA==}
     peerDependencies:
-      eslint: 10.5.0
+      eslint: 10.6.0
 
   '@book000/node-utils@1.24.274':
     resolution: {integrity: sha512-GLt0OOcYjShe89Nfxa4H8PqKEjlK2ET3dqWxMrYd3l0UhHdlDL0ZK5vzd7RTGY22Ecz6ZUdC7DdC/ldd36s+MA==}
@@ -326,8 +322,23 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/eslint-plugin@8.63.0':
+    resolution: {integrity: sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.63.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/parser@8.61.0':
     resolution: {integrity: sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.63.0':
+    resolution: {integrity: sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -345,12 +356,22 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/project-service@8.63.0':
+    resolution: {integrity: sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.61.0':
     resolution: {integrity: sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/scope-manager@8.62.1':
     resolution: {integrity: sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.63.0':
+    resolution: {integrity: sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.61.0':
@@ -365,8 +386,21 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/tsconfig-utils@8.63.0':
+    resolution: {integrity: sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/type-utils@8.61.0':
     resolution: {integrity: sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.63.0':
+    resolution: {integrity: sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -380,6 +414,10 @@ packages:
     resolution: {integrity: sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.63.0':
+    resolution: {integrity: sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.61.0':
     resolution: {integrity: sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -388,6 +426,12 @@ packages:
 
   '@typescript-eslint/typescript-estree@8.62.1':
     resolution: {integrity: sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/typescript-estree@8.63.0':
+    resolution: {integrity: sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -406,12 +450,23 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/utils@8.63.0':
+    resolution: {integrity: sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@8.61.0':
     resolution: {integrity: sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/visitor-keys@8.62.1':
     resolution: {integrity: sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.63.0':
+    resolution: {integrity: sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   acorn-jsx@5.3.2:
@@ -792,12 +847,6 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
-  eslint-plugin-unicorn@65.0.1:
-    resolution: {integrity: sha512-daCrQrgxOoOz2uMPWB3Y3vvv/5q+ncwICI8IjoebiwtW87CaY4tAN5EEiRXTYVnf7qi1v1BGBdHOSnZLV0rx6A==}
-    engines: {node: ^20.10.0 || >=21.0.0}
-    peerDependencies:
-      eslint: '>=9.38.0'
-
   eslint-plugin-unicorn@71.1.0:
     resolution: {integrity: sha512-dn3YmR3qLLUeYyo/os3ubZ7UHQJ1WbBAgC9cIhnLTyMj9J6kivuc2U1fCmYetLexUlTDVYtBqhjSj/VaebTe6Q==}
     engines: {node: '>=22'}
@@ -956,10 +1005,6 @@ packages:
 
   globals@15.15.0:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
-    engines: {node: '>=18'}
-
-  globals@17.6.0:
-    resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
     engines: {node: '>=18'}
 
   globals@17.7.0:
@@ -1631,6 +1676,13 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  typescript-eslint@8.63.0:
+    resolution: {integrity: sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -1715,17 +1767,15 @@ packages:
 
 snapshots:
 
-  '@babel/helper-validator-identifier@7.29.7': {}
-
-  '@book000/eslint-config@1.15.4(eslint@10.6.0)(typescript@6.0.3)':
+  '@book000/eslint-config@1.15.44(eslint@10.6.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/parser': 8.61.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
       eslint: 10.6.0
       eslint-config-prettier: 10.1.8(eslint@10.6.0)
-      eslint-plugin-unicorn: 65.0.1(eslint@10.6.0)
-      globals: 17.6.0
+      eslint-plugin-unicorn: 71.1.0(eslint@10.6.0)
+      globals: 17.7.0
       neostandard: 0.13.0(eslint@10.6.0)(typescript@6.0.3)
-      typescript-eslint: 8.61.0(eslint@10.6.0)(typescript@6.0.3)
+      typescript-eslint: 8.63.0(eslint@10.6.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -1925,6 +1975,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.63.0
+      '@typescript-eslint/type-utils': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.63.0
+      eslint: 10.6.0
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.61.0(eslint@10.6.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.61.0
@@ -1937,10 +2003,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.63.0
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.63.0
+      debug: 4.4.3
+      eslint: 10.6.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.61.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@6.0.3)
+      '@typescript-eslint/types': 8.62.1
       debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -1950,6 +2028,15 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.62.1
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.63.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.63.0
       debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -1965,11 +2052,20 @@ snapshots:
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/visitor-keys': 8.62.1
 
+  '@typescript-eslint/scope-manager@8.63.0':
+    dependencies:
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/visitor-keys': 8.63.0
+
   '@typescript-eslint/tsconfig-utils@8.61.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
   '@typescript-eslint/tsconfig-utils@8.62.1(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/tsconfig-utils@8.63.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
@@ -1985,9 +2081,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.63.0(eslint@10.6.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
+      debug: 4.4.3
+      eslint: 10.6.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@8.61.0': {}
 
   '@typescript-eslint/types@8.62.1': {}
+
+  '@typescript-eslint/types@8.63.0': {}
 
   '@typescript-eslint/typescript-estree@8.61.0(typescript@6.0.3)':
     dependencies:
@@ -2019,6 +2129,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.63.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/visitor-keys': 8.63.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.61.0(eslint@10.6.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.6.0)
@@ -2041,6 +2166,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.63.0(eslint@10.6.0)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.6.0)
+      '@typescript-eslint/scope-manager': 8.63.0
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
+      eslint: 10.6.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.61.0':
     dependencies:
       '@typescript-eslint/types': 8.61.0
@@ -2049,6 +2185,11 @@ snapshots:
   '@typescript-eslint/visitor-keys@8.62.1':
     dependencies:
       '@typescript-eslint/types': 8.62.1
+      eslint-visitor-keys: 5.0.1
+
+  '@typescript-eslint/visitor-keys@8.63.0':
+    dependencies:
+      '@typescript-eslint/types': 8.63.0
       eslint-visitor-keys: 5.0.1
 
   acorn-jsx@5.3.2(acorn@8.17.0):
@@ -2457,10 +2598,10 @@ snapshots:
     dependencies:
       eslint: 10.6.0
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0))(eslint-plugin-n@18.2.1(eslint@10.6.0)(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3))(eslint-plugin-promise@7.3.0(eslint@10.6.0))(eslint@10.6.0):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0))(eslint-plugin-n@18.2.1(eslint@10.6.0)(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3))(eslint-plugin-promise@7.3.0(eslint@10.6.0))(eslint@10.6.0):
     dependencies:
       eslint: 10.6.0
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)
       eslint-plugin-n: 18.2.1(eslint@10.6.0)(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3)
       eslint-plugin-promise: 7.3.0(eslint@10.6.0)
 
@@ -2472,11 +2613,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.61.0(eslint@10.6.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.6.0):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.6.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.61.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
       eslint: 10.6.0
       eslint-import-resolver-node: 0.3.10
     transitivePeerDependencies:
@@ -2489,7 +2630,7 @@ snapshots:
       eslint: 10.6.0
       eslint-compat-utils: 0.5.1(eslint@10.6.0)
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -2500,7 +2641,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.6.0
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.61.0(eslint@10.6.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.6.0)
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.6.0)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -2512,7 +2653,7 @@ snapshots:
       string.prototype.trimend: 1.0.10
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.61.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -2574,25 +2715,6 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
-
-  eslint-plugin-unicorn@65.0.1(eslint@10.6.0):
-    dependencies:
-      '@babel/helper-validator-identifier': 7.29.7
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.6.0)
-      change-case: 5.4.4
-      ci-info: 4.4.0
-      core-js-compat: 3.49.0
-      detect-indent: 7.0.2
-      eslint: 10.6.0
-      find-up-simple: 1.0.1
-      globals: 17.7.0
-      indent-string: 5.0.0
-      is-builtin-module: 5.0.0
-      jsesc: 3.1.0
-      pluralize: 8.0.0
-      regjsparser: 0.13.2
-      semver: 7.8.5
-      strip-indent: 4.1.1
 
   eslint-plugin-unicorn@71.1.0(eslint@10.6.0):
     dependencies:
@@ -2790,8 +2912,6 @@ snapshots:
       is-glob: 4.0.3
 
   globals@15.15.0: {}
-
-  globals@17.6.0: {}
 
   globals@17.7.0: {}
 
@@ -3533,6 +3653,17 @@ snapshots:
       '@typescript-eslint/parser': 8.61.0(eslint@10.6.0)(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
       '@typescript-eslint/utils': 8.61.0(eslint@10.6.0)(typescript@6.0.3)
+      eslint: 10.6.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript-eslint@8.63.0(eslint@10.6.0)(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
       eslint: 10.6.0
       typescript: 6.0.3
     transitivePeerDependencies:

--- a/src/lib/epgstation.ts
+++ b/src/lib/epgstation.ts
@@ -45,26 +45,27 @@ export interface EPGChannel {
 
 export class EPGStation {
   public async getRecordeds(): Promise<EPGRecorded[]> {
-    const res = await fetch(
+    const response = await fetch(
       'http://localhost:8888/api/recorded?isHalfWidth=false&limit=300'
     )
-    if (!res.ok)
-      throw new Error(`EPGStation getRecordeds failed: ${res.status}`)
-    return ((await res.json()) as { records: EPGRecorded[] }).records
+    if (!response.ok)
+      throw new Error(`EPGStation getRecordeds failed: ${response.status}`)
+    return ((await response.json()) as { records: EPGRecorded[] }).records
   }
 
   public async getRecordings(): Promise<EPGRecorded[]> {
-    const res = await fetch(
+    const response = await fetch(
       'http://localhost:8888/api/recording?&isHalfWidth=true&limit=300'
     )
-    if (!res.ok)
-      throw new Error(`EPGStation getRecordings failed: ${res.status}`)
-    return ((await res.json()) as { records: EPGRecorded[] }).records
+    if (!response.ok)
+      throw new Error(`EPGStation getRecordings failed: ${response.status}`)
+    return ((await response.json()) as { records: EPGRecorded[] }).records
   }
 
   public async getChannels(): Promise<EPGChannel[]> {
-    const res = await fetch('http://localhost:8888/api/channels')
-    if (!res.ok) throw new Error(`EPGStation getChannels failed: ${res.status}`)
-    return (await res.json()) as EPGChannel[]
+    const response = await fetch('http://localhost:8888/api/channels')
+    if (!response.ok)
+      throw new Error(`EPGStation getChannels failed: ${response.status}`)
+    return (await response.json()) as EPGChannel[]
   }
 }

--- a/src/lib/syoboi.ts
+++ b/src/lib/syoboi.ts
@@ -71,16 +71,17 @@ export class Syoboi {
   public async requestJSON(
     options: SyoboiJsonOptions
   ): Promise<SyoboiJsonResult> {
-    const params = new URLSearchParams(
+    const parameters = new URLSearchParams(
       Object.entries(options).map(
         ([k, v]) => [k, String(v)] as [string, string]
       )
     )
-    const res = await fetch(
-      `https://cal.syoboi.jp/json.php?${params.toString()}`
+    const response = await fetch(
+      `https://cal.syoboi.jp/json.php?${parameters.toString()}`
     )
-    if (!res.ok) throw new Error(`Syoboi requestJSON failed: ${res.status}`)
-    const data = (await res.json()) as {
+    if (!response.ok)
+      throw new Error(`Syoboi requestJSON failed: ${response.status}`)
+    const data = (await response.json()) as {
       Titles: Record<string, SyoboiJsonResult>
     }
     return data.Titles[options.TID]
@@ -89,16 +90,17 @@ export class Syoboi {
   public async requestRSS(
     options: SyoboiRssOptions
   ): Promise<SyoboiRssResult[]> {
-    const params = new URLSearchParams(
+    const parameters = new URLSearchParams(
       Object.entries(options).map(
         ([k, v]) => [k, String(v)] as [string, string]
       )
     )
-    const res = await fetch(
-      `https://cal.syoboi.jp/rss2.php?${params.toString()}`
+    const response = await fetch(
+      `https://cal.syoboi.jp/rss2.php?${parameters.toString()}`
     )
-    if (!res.ok) throw new Error(`Syoboi requestRSS failed: ${res.status}`)
-    const data = (await res.json()) as { items: SyoboiRssResult[] }
+    if (!response.ok)
+      throw new Error(`Syoboi requestRSS failed: ${response.status}`)
+    const data = (await response.json()) as { items: SyoboiRssResult[] }
     return data.items
   }
 }

--- a/src/lib/utlis.ts
+++ b/src/lib/utlis.ts
@@ -9,24 +9,30 @@ import { Syoboi } from './syoboi'
 const encodedDataFile = config.get<string>('encodedDataFile')
 
 export function formatDate(date: Date, format: string): string {
-  format = format.replaceAll('yyyy', String(date.getFullYear()))
+  format = format.replaceAll('yyyy', () => String(date.getFullYear()))
   format = format.replaceAll(
     'MM',
-    ('0' + (date.getMonth() + 1).toString()).slice(-2)
+    () => ('0' + (date.getMonth() + 1).toString()).slice(-2)
   )
-  format = format.replaceAll('dd', ('0' + date.getDate().toString()).slice(-2))
-  format = format.replaceAll('HH', ('0' + date.getHours().toString()).slice(-2))
+  format = format.replaceAll(
+    'dd',
+    () => ('0' + date.getDate().toString()).slice(-2)
+  )
+  format = format.replaceAll(
+    'HH',
+    () => ('0' + date.getHours().toString()).slice(-2)
+  )
   format = format.replaceAll(
     'mm',
-    ('0' + date.getMinutes().toString()).slice(-2)
+    () => ('0' + date.getMinutes().toString()).slice(-2)
   )
   format = format.replaceAll(
     'ss',
-    ('0' + date.getSeconds().toString()).slice(-2)
+    () => ('0' + date.getSeconds().toString()).slice(-2)
   )
   format = format.replaceAll(
     'SSS',
-    ('00' + date.getMilliseconds().toString()).slice(-3)
+    () => ('00' + date.getMilliseconds().toString()).slice(-3)
   )
   return format
 }
@@ -37,11 +43,11 @@ interface File {
   path: string
 }
 
-export function getTSFiles(dirPath: string, subPath: string): File[] {
-  const searchPath = path.join(dirPath, subPath)
+export function getTSFiles(directoryPath: string, subPath: string): File[] {
+  const searchPath = path.join(directoryPath, subPath)
   const files: File[] = []
-  const dirs = fs.readdirSync(searchPath)
-  for (const filename of dirs) {
+  const directories = fs.readdirSync(searchPath)
+  for (const filename of directories) {
     const path = `${searchPath}/${filename}`
     const stat = fs.statSync(path)
     if (stat.isFile() && path.endsWith('.ts')) {
@@ -81,8 +87,8 @@ export function addEncoded(file: File): void {
 }
 
 // https://github.com/l3tnun/EPGStation/blob/6dbcb58d6ab13b99b1489b5b0f60788f8b802599/src/util/StrUtil.ts#L64
-export function toHalf(str: string): string {
-  const tmp = str.replaceAll(/[！-～]/g, (s) => {
+export function toHalf(string_: string): string {
+  const temporary = string_.replaceAll(/[！-～]/g, (s) => {
     const c = s.codePointAt(0)
     if (!c) {
       return ''
@@ -90,13 +96,13 @@ export function toHalf(str: string): string {
     return String.fromCodePoint(c - 0xfe_e0)
   })
 
-  return tmp
+  return temporary
     .replaceAll('”', '"')
     .replaceAll('’', "'")
     .replaceAll('‘', '`')
     .replaceAll('￥', '\\')
 
-    .replaceAll('\u3000', ' ')
+    .replaceAll('\u{3000}', ' ')
     .replaceAll('〜', '~')
 }
 
@@ -180,7 +186,7 @@ export async function processFileName(
 
 export function getJLSECommand(
   inputPath: string,
-  outputDir: string,
+  outputDirectory: string,
   outputFileName: string
 ): string[] {
   if (!inputPath.endsWith('.ts')) {
@@ -193,7 +199,7 @@ export function getJLSECommand(
     '-t',
     'cutcm_logo',
     `-d`,
-    outputDir,
+    outputDirectory,
     `-n`,
     outputFileName,
     '-o',
@@ -264,7 +270,7 @@ export async function sendDiscordMessage(
   const logger = Logger.configure('Utils.sendDiscordMessage')
   const discordChannelId = config.get<string>('discordChannelId')
   const discordToken = config.get<string>('discordToken')
-  const res = await fetch(
+  const response = await fetch(
     `https://discord.com/api/channels/${discordChannelId}/messages`,
     {
       method: 'POST',
@@ -278,12 +284,13 @@ export async function sendDiscordMessage(
       }),
     }
   )
-  if (!res.ok) throw new Error(`sendDiscordMessage failed: ${res.status}`)
-  logger.info(`📧 sendDiscordMessage: ${res.status}`)
+  if (!response.ok)
+    throw new Error(`sendDiscordMessage failed: ${response.status}`)
+  logger.info(`📧 sendDiscordMessage: ${response.status}`)
 }
 
-export function pad(num: number, size = 2): string {
-  return ('00' + num.toString()).slice(-size)
+export function pad(number_: number, size = 2): string {
+  return ('00' + number_.toString()).slice(-size)
 }
 
 export function msToTime(s: number): string {
@@ -306,11 +313,11 @@ export async function checkLatest(): Promise<boolean> {
   const branch = config.has('repo.branch')
     ? config.get<string>('repo.branch')
     : 'master'
-  const res = await fetch(
+  const response = await fetch(
     `https://api.github.com/repos/${repo}/commits/${branch}`
   )
-  if (!res.ok) throw new Error(`checkLatest failed: ${res.status}`)
-  const data = (await res.json()) as { sha: string }
+  if (!response.ok) throw new Error(`checkLatest failed: ${response.status}`)
+  const data = (await response.json()) as { sha: string }
   const latest = data.sha
   const current = execSync('git rev-parse HEAD').toString().trim()
   if (latest !== current) {
@@ -325,10 +332,10 @@ export function formatBytes(bytes: number, dm = 2): string {
   if (bytes === 0) return '0 Bytes'
   const k = 1024
   const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
-  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  const index = Math.floor(Math.log(bytes) / Math.log(k))
   return (
-    Number.parseFloat((bytes / Math.pow(k, i)).toFixed(dm)).toString() +
+    Number((bytes / Math.pow(k, index)).toFixed(dm)).toString() +
     ' ' +
-    sizes[i]
+    sizes[index]
   )
 }

--- a/src/lib/utlis.ts
+++ b/src/lib/utlis.ts
@@ -10,29 +10,23 @@ const encodedDataFile = config.get<string>('encodedDataFile')
 
 export function formatDate(date: Date, format: string): string {
   format = format.replaceAll('yyyy', () => String(date.getFullYear()))
-  format = format.replaceAll(
-    'MM',
-    () => ('0' + (date.getMonth() + 1).toString()).slice(-2)
+  format = format.replaceAll('MM', () =>
+    ('0' + (date.getMonth() + 1).toString()).slice(-2)
   )
-  format = format.replaceAll(
-    'dd',
-    () => ('0' + date.getDate().toString()).slice(-2)
+  format = format.replaceAll('dd', () =>
+    ('0' + date.getDate().toString()).slice(-2)
   )
-  format = format.replaceAll(
-    'HH',
-    () => ('0' + date.getHours().toString()).slice(-2)
+  format = format.replaceAll('HH', () =>
+    ('0' + date.getHours().toString()).slice(-2)
   )
-  format = format.replaceAll(
-    'mm',
-    () => ('0' + date.getMinutes().toString()).slice(-2)
+  format = format.replaceAll('mm', () =>
+    ('0' + date.getMinutes().toString()).slice(-2)
   )
-  format = format.replaceAll(
-    'ss',
-    () => ('0' + date.getSeconds().toString()).slice(-2)
+  format = format.replaceAll('ss', () =>
+    ('0' + date.getSeconds().toString()).slice(-2)
   )
-  format = format.replaceAll(
-    'SSS',
-    () => ('00' + date.getMilliseconds().toString()).slice(-3)
+  format = format.replaceAll('SSS', () =>
+    ('00' + date.getMilliseconds().toString()).slice(-3)
   )
   return format
 }
@@ -60,7 +54,7 @@ export function getTSFiles(directoryPath: string, subPath: string): File[] {
     if (stat.isDirectory()) {
       files.push(
         ...getTSFiles(
-          dirPath,
+          directoryPath,
           `${subPath === '' ? '' : subPath + '/'}${filename}`
         )
       )

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,8 +16,8 @@ import {
   sendDiscordMessage,
 } from './lib/utlis'
 
-const tsFilesDirPath = config.get<string>('tsFilesDirPath')
-const outputDirPath = config.get<string>('outputDirPath')
+const tsFilesDirectoryPath = config.get<string>('tsFilesDirPath')
+const outputDirectoryPath = config.get<string>('outputDirPath')
 
 async function main(): Promise<void> {
   const logger = Logger.configure('main')
@@ -39,7 +39,7 @@ async function main(): Promise<void> {
   logger.info('📡 Fetch EPGStation Channels')
   const channels = await epg.getChannels()
 
-  const files = getTSFiles(tsFilesDirPath, '')
+  const files = getTSFiles(tsFilesDirectoryPath, '')
 
   for (const file of files) {
     if (isEncoded(file)) {
@@ -60,37 +60,37 @@ async function main(): Promise<void> {
       continue
     }
 
-    const outputDir = file.dirname.startsWith('anime')
-      ? path.join(outputDirPath, 'anime', dirname)
-      : path.join(outputDirPath, file.dirname)
-    if (!fs.existsSync(outputDir)) {
-      fs.mkdirSync(outputDir, { recursive: true })
+    const outputDirectory = file.dirname.startsWith('anime')
+      ? path.join(outputDirectoryPath, 'anime', dirname)
+      : path.join(outputDirectoryPath, file.dirname)
+    if (!fs.existsSync(outputDirectory)) {
+      fs.mkdirSync(outputDirectory, { recursive: true })
     }
 
-    const jlseCmd = getJLSECommand(file.path, outputDir, filename)
-    logger.info(`🚀 JLSE Command: /usr/bin/jlse ${jlseCmd.join(' ')}`)
+    const jlseCommand = getJLSECommand(file.path, outputDirectory, filename)
+    logger.info(`🚀 JLSE Command: /usr/bin/jlse ${jlseCommand.join(' ')}`)
 
     const jlseStartTime = performance.now()
-    const jlseProcess = spawn('/usr/bin/jlse', jlseCmd)
+    const jlseProcess = spawn('/usr/bin/jlse', jlseCommand)
     logger.info(`🔢 Process ID: ${process.pid}`)
     logger.info(`🔢 Child Process ID: ${jlseProcess.pid}`)
 
     jlseProcess.stdout.on('data', (chunk: { toString: () => string }) => {
-      const strChunk = chunk.toString().trim()
-      if (strChunk.trim().length === 0) return
-      if (strChunk.trim().endsWith('%') || strChunk.trim().endsWith('\r')) {
-        process.stdout.write('\r' + strChunk.trim())
+      const stringChunk = chunk.toString().trim()
+      if (stringChunk.trim().length === 0) return
+      if (stringChunk.trim().endsWith('%') || stringChunk.trim().endsWith('\r')) {
+        process.stdout.write('\r' + stringChunk.trim())
       } else {
-        logger.info(strChunk.trim())
+        logger.info(stringChunk.trim())
       }
     })
     jlseProcess.stderr.on('data', (chunk: { toString: () => string }) => {
-      const strChunk = chunk.toString().trim()
-      if (strChunk.trim().length === 0) return
-      if (strChunk.trim().endsWith('%') || strChunk.trim().endsWith('\r')) {
-        process.stdout.write('\r' + strChunk.trim())
+      const stringChunk = chunk.toString().trim()
+      if (stringChunk.trim().length === 0) return
+      if (stringChunk.trim().endsWith('%') || stringChunk.trim().endsWith('\r')) {
+        process.stdout.write('\r' + stringChunk.trim())
       } else {
-        logger.error(strChunk.trim())
+        logger.error(stringChunk.trim())
       }
     })
 
@@ -107,19 +107,20 @@ async function main(): Promise<void> {
     }
     addEncoded(file)
 
+    const outputFilePath = path.join(outputDirectory, filename) + '.mp4'
+    const outputFileSize = fs.statSync(outputFilePath).size
+
     await sendDiscordMessage('', {
       title: `CMカット完了`,
       description: `\`${file.name}\` を CMカットしました`,
       fields: [
         {
           name: '出力先',
-          value: path.join(outputDir, filename) + '.mp4',
+          value: outputFilePath,
         },
         {
           name: 'ファイルサイズ',
-          value: formatBytes(
-            fs.statSync(path.join(outputDir, filename) + '.mp4').size
-          ),
+          value: formatBytes(outputFileSize),
         },
         {
           name: 'エンコード処理時間',

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,7 +78,10 @@ async function main(): Promise<void> {
     jlseProcess.stdout.on('data', (chunk: { toString: () => string }) => {
       const stringChunk = chunk.toString().trim()
       if (stringChunk.trim().length === 0) return
-      if (stringChunk.trim().endsWith('%') || stringChunk.trim().endsWith('\r')) {
+      if (
+        stringChunk.trim().endsWith('%') ||
+        stringChunk.trim().endsWith('\r')
+      ) {
         process.stdout.write('\r' + stringChunk.trim())
       } else {
         logger.info(stringChunk.trim())
@@ -87,7 +90,10 @@ async function main(): Promise<void> {
     jlseProcess.stderr.on('data', (chunk: { toString: () => string }) => {
       const stringChunk = chunk.toString().trim()
       if (stringChunk.trim().length === 0) return
-      if (stringChunk.trim().endsWith('%') || stringChunk.trim().endsWith('\r')) {
+      if (
+        stringChunk.trim().endsWith('%') ||
+        stringChunk.trim().endsWith('\r')
+      ) {
         process.stdout.write('\r' + stringChunk.trim())
       } else {
         logger.error(stringChunk.trim())


### PR DESCRIPTION
## 概要

Renovate PR #2542 (`@book000/eslint-config` 1.15.4 -> 1.15.44) を取り込むと `eslint-plugin-unicorn` の新規/変更ルールにより既存コードで 32 件の lint エラーが発生し、CI (`Node CI / node-ci (.)`) が失敗します。本 PR はこのブランチを基にし、それらの lint エラーを機械的に修正したものです。

## 内容

- `unicorn/name-replacements`: `res`->`response`、`params`(自動修正済み)、`dirPath`->`directoryPath`、`tsFilesDirPath`/`outputDirPath`->`tsFilesDirectoryPath`/`outputDirectoryPath`、`outputDir`->`outputDirectory`、`jlseCmd`->`jlseCommand`、`strChunk`->`stringChunk` など変数名の変更（挙動は変えていません。設定キー名 `tsFilesDirPath`/`outputDirPath` はそのまま維持しています）
- `unicorn/no-unsafe-string-replacement`: `String#replaceAll()` の置換値を関数でラップ（`$` パターン展開を回避）
- `unicorn/prefer-number-coercion`: `Number.parseFloat()` -> `Number()`
- `unicorn/max-nested-calls`: `main.ts` でネストしていた呼び出しを変数に切り出し

## 確認

- `pnpm run lint`（prettier + eslint + tsc）ローカルで全てクリーン
- リポジトリにテストコードなし

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
