### PR TITLE
chore: .worktreeinclude を追加し config/ の必須設定ファイルを対象に含める

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+config/default.yml
+config/local.yml
+config/*.yml


### PR DESCRIPTION
## 概要

`.worktreeinclude` を新規作成し、以下のパターンを追加した。

```
config/default.yml
config/local.yml
config/*.yml
```

## 根拠

- README.md の Installation 手順 4 で `config/default.yml` を手動作成する旨が明記されている（`.env.example` 等のサンプルは存在しない）
- `package.json` は `config` npm パッケージ（および `@types/config`）に依存しており、慣例的に `config/` ディレクトリから設定を読み込む
- `src/main.ts` で `config.get<string>('tsFilesDirPath')` / `config.get<string>('outputDirPath')` を使用
- `src/lib/utlis.ts` で `config.get<string>('encodedDataFile')` / `config.get<string>('discordChannelId')` / `config.get<string>('discordToken')` を使用（Discord トークンという機密情報を含む）
- `config/` ディレクトリはリポジトリに含まれておらず（`git ls-files` に該当なし）、コミット対象でもないが、README により必須のローカルファイルであることが明記されている

これにより、新しい git worktree を作成した際にも `config/` 配下の設定ファイルが引き継がれるようになる。

関連: https://github.com/book000/book000/issues/132
