### PR TITLE
fix(config): shim config@5.0.0's broken published types

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "devDependencies": {
     "@book000/eslint-config": "1.16.34",
     "@book000/node-utils": "1.25.45",
-    "@types/config": "4.4.0",
     "@types/node": "24.13.3",
     "config": "5.0.0",
     "eslint": "10.8.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@book000/node-utils": "1.25.45",
     "@types/config": "4.4.0",
     "@types/node": "24.13.3",
-    "config": "4.4.2",
+    "config": "5.0.0",
     "eslint": "10.8.1",
     "eslint-config-standard": "17.1.0",
     "eslint-plugin-import": "2.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@book000/node-utils':
         specifier: 1.25.45
         version: 1.25.45(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
-      '@types/config':
-        specifier: 4.4.0
-        version: 4.4.0
       '@types/node':
         specifier: 24.13.3
         version: 24.13.3
@@ -396,10 +393,6 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=8.40.0'
-
-  '@types/config@4.4.0':
-    resolution: {integrity: sha512-+82/thz8il6uR6mWFuMTWyC+jSXE4PIZUPmAfKUDOuvNULq3BPLM+tSKsAe3eOIOMKx5azvg3Q3JljWV9yX7aw==}
-    deprecated: This is a stub types definition. config provides its own type definitions, so you do not need this installed.
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -2126,10 +2119,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  '@types/config@4.4.0':
-    dependencies:
-      config: 5.0.0
 
   '@types/esrecurse@4.3.1': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: 24.13.3
         version: 24.13.3
       config:
-        specifier: 4.4.2
-        version: 4.4.2
+        specifier: 5.0.0
+        version: 5.0.0
       eslint:
         specifier: 10.8.1
         version: 10.8.1
@@ -634,9 +634,9 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  config@4.4.2:
-    resolution: {integrity: sha512-5HJD7TX70gOG2dAd72eDjDeSTYn6D8nOiKgysQQS8mRUo9X1wDtlzb1JlmIWkP+sM9zKRVdYJxmj+qmCsYu6DQ==}
-    engines: {node: '>= 20.0.0'}
+  config@5.0.0:
+    resolution: {integrity: sha512-LaZ/Z113nYJ4YNrH13dWdHvgIehYACiJZPxFVK8ykqO+6CaMAiJ7NkyrxTPAimMJoIKn7qPrvTFzIBPgm4/SLA==}
+    engines: {node: '>= 20.11.0'}
 
   convert-hrtime@5.0.0:
     resolution: {integrity: sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==}
@@ -2129,7 +2129,7 @@ snapshots:
 
   '@types/config@4.4.0':
     dependencies:
-      config: 4.4.2
+      config: 5.0.0
 
   '@types/esrecurse@4.3.1': {}
 
@@ -2410,7 +2410,7 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  config@4.4.2:
+  config@5.0.0:
     dependencies:
       json5: 2.2.3
 

--- a/src/types/config-shim.d.ts
+++ b/src/types/config-shim.d.ts
@@ -1,0 +1,12 @@
+// ponytail: config@5.0.0's published .d.ts is broken under Node16 module
+// resolution (types/lib/config.d.ts imports a type from its .mjs sibling
+// without a `resolution-mode` attribute, which tsc rejects). tsconfig.json
+// redirects the "config" specifier to this stub for type-checking only
+// (runtime resolution via Node/tsx is unaffected), until upstream fixes
+// node-config/node-config's published types.
+declare const config: {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- T is cast-only, mirrors config's own (broken) upstream signature
+  get<T>(setting: string): T
+  has(setting: string): boolean
+}
+export = config

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,8 @@
     "experimentalDecorators": true,
     "newLine": "LF",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "config": ["./src/types/config-shim.d.ts"]
     }
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## What

Unblocks #2692 (`config` 4.4.2 → 5.0.0).

## Why CI was failing

`config@5.0.0`'s published `types/lib/config.d.ts` does:

```ts
type Config = import("./config.mjs").Config;
```

This is a type-only import of an ECMAScript module (`config.mjs`) from a file tsc treats as CommonJS, since the `config` package ships no `exports` map / `"type"` field. Under this project's `moduleResolution: "node16"`, tsc rejects this as `TS1542` ("Type import of an ECMAScript module from a CommonJS module must have a 'resolution-mode' attribute"). This is an upstream bug in node-config/node-config; there is no newer patch release to pick up instead (5.0.0 is current latest).

This repo's CLAUDE.md forbids `skipLibCheck: true`, so instead this redirects the `"config"` module specifier via a `tsconfig.json` `paths` entry to a small local ambient `.d.ts` stub covering the `get`/`has` calls this project actually uses. This only affects type-checking — runtime module resolution via Node/tsx still goes through the real `config` package, unaffected.

Also drops the now-orphaned `@types/config` devDependency, since v5 bundles its own types.

## Verification

- `pnpm run lint` (prettier + eslint + tsc): green
- `pnpm run compile`: green